### PR TITLE
Added backup of verb import for mongodb.

### DIFF
--- a/jehle_verb_mongo.metadata.json
+++ b/jehle_verb_mongo.metadata.json
@@ -1,0 +1,1 @@
+{"options":{},"indexes":[{"v":{"$numberInt":"2"},"key":{"_id":{"$numberInt":"1"}},"name":"_id_","ns":"fred-jehle.conjugaciones"}],"uuid":"34cd3da0bd2246dd99bfdadf6f03473f"}


### PR DESCRIPTION
Request to add a mongodb backup of the verb list to your repository. 

I found your repo looking for the exact verb list you have here. Although I could have used postgres, I prefer Mongo. The import was straight forward and wanted to let you know it's available if you'd like it. If not, feel free to reject this PR, no hard feelings.

I'm happy to make updates to this PR as well, just let me know.

If the code I used is useful, it was trivial:
```const csvtojson = require("csvtojson");
const mongodb = require("mongodb").MongoClient;
const url = "mongodb://localhost:27017/";

csvtojson()
    .fromFile("jehle_verb_database.csv")
    .then(data => {
        mongodb.connect(url, { useNewUrlParser: true, useUnifiedTopology: true },
            (error, client) => {
                client
                    .db("fred-jehle")
                    .collection("conjugaciones")
                    .insertMany(data, (err, res) => {
                        client.close();
                    });
            }
        );
    });
```

Cheers 